### PR TITLE
Add support for a prompt file as input to allow for more complex prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,11 +5,26 @@ from app.agent.manus import Manus
 from app.logger import logger
 
 
+def get_prompt(args):
+    prompt = ""
+    if args.prompt_file:
+        with open(args.prompt_file, "r") as file:
+            return file.read()
+
+    return args.prompt if args.prompt else input("Enter your prompt: ")
+
+
 async def main():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="Run Manus agent with a prompt")
     parser.add_argument(
         "--prompt", type=str, required=False, help="Input prompt for the agent"
+    )
+    parser.add_argument(
+        "--prompt_file",
+        type=str,
+        required=False,
+        help="Input prompt for the agent through a file",
     )
     args = parser.parse_args()
 
@@ -17,7 +32,7 @@ async def main():
     agent = await Manus.create()
     try:
         # Use command line prompt if provided, otherwise ask for input
-        prompt = args.prompt if args.prompt else input("Enter your prompt: ")
+        prompt = get_prompt(args)
         if not prompt.strip():
             logger.warning("Empty prompt provided.")
             return


### PR DESCRIPTION
Small change that allows the file to be passed instead of the prompt directly. This allows for more complex/larger prompts to be used. 

**Features**
- Use the `--prompt-file` parameter to pass a file containing the prompt.
- This allows the prompt itself to be large, and not captured as part of the command invocation. 

**Result**
- Sample command: 
```
$ python main.py --prompt_file gather_info.txt
```